### PR TITLE
Fix responsive width

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=320, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>2GIS Subscription</title>
   </head>
   <body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import AppRoutes from './routes'
 const App: React.FC = () => {
   return (
     <SubscriptionProvider>
-      <div className="w-mobile h-screen mx-auto bg-background">
+      <div className="w-full max-w-[586px] h-screen mx-auto bg-background">
         <AppRoutes />
       </div>
     </SubscriptionProvider>

--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -11,7 +11,7 @@ const BottomNavigation: React.FC<BottomNavigationProps> = ({
   onItemClick 
 }) => {
   return (
-    <div className="fixed bottom-0 left-0 w-mobile h-[82px] bg-background/80 backdrop-blur-[20px] border-t border-gray-200 z-bottom-nav">
+    <div className="fixed bottom-0 left-0 w-full max-w-[586px] mx-auto h-[82px] bg-background/80 backdrop-blur-[20px] border-t border-gray-200 z-bottom-nav">
       <div className="flex items-center justify-around h-full pt-8">
         <button
           onClick={() => onItemClick?.('overview')}

--- a/src/components/FixedSubscribeButton.tsx
+++ b/src/components/FixedSubscribeButton.tsx
@@ -28,7 +28,7 @@ const FixedSubscribeButton: React.FC<FixedSubscribeButtonProps> = ({
   const totalPrice = basePrice + modulesPrice
 
   return (
-    <div className={`fixed bottom-0 left-0 right-0 z-50 bg-white border-t border-gray-200 px-4 py-4 max-w-[320px] mx-auto ${className}`}>
+    <div className={`fixed bottom-0 left-0 right-0 z-50 bg-white border-t border-gray-200 px-4 py-4 max-w-[586px] mx-auto ${className}`}>
       <div className="flex items-center justify-between mb-3">
         <div className="text-sm text-foreground-secondary">
           {selectedModules.length > 0 ? `${selectedModules.length} модуль${selectedModules.length === 1 ? '' : selectedModules.length < 5 ? 'а' : 'ей'} выбрано` : 'Базовый тариф'}

--- a/src/components/FooterNav.tsx
+++ b/src/components/FooterNav.tsx
@@ -13,7 +13,7 @@ const FooterNav: React.FC = () => {
   ]
 
   return (
-    <nav className="fixed bottom-0 w-mobile h-[82px] bg-background/80 backdrop-blur-[20px] z-bottom-nav border-t border-gray-200">
+    <nav className="fixed bottom-0 w-full max-w-[586px] mx-auto h-[82px] bg-background/80 backdrop-blur-[20px] z-bottom-nav border-t border-gray-200">
       <div className="flex items-center justify-around h-full px-4">
         {navItems.map((item) => {
           const Icon = item.icon

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -36,7 +36,7 @@ const Dashboard: React.FC = () => {
   ]
 
   return (
-    <div className="relative w-mobile h-screen overflow-hidden">
+    <div className="relative w-full max-w-[586px] h-screen mx-auto overflow-hidden">
       {/* Статус бар */}
       <div className="absolute top-0 left-0 right-0 h-5 bg-white/80 backdrop-blur-[20px] z-status-bar flex items-center justify-between px-2 text-xs font-semibold">
         <span>LTE</span>

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -20,7 +20,7 @@
   }
   
   .map-background {
-    @apply absolute top-0 left-0 w-mobile h-screen z-map object-cover;
+    @apply absolute top-0 left-0 w-full max-w-[586px] h-screen z-map object-cover mx-auto;
   }
   
   .bottom-sheet {
@@ -37,7 +37,7 @@
   }
   
   .bottom-nav {
-    @apply fixed bottom-0 w-mobile h-[82px] bg-background/80 z-bottom-nav;
+    @apply fixed bottom-0 w-full max-w-[586px] bg-background/80 h-[82px] z-bottom-nav mx-auto;
   }
   
   /* Скрытие скроллбара */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -40,8 +40,8 @@ export default {
       height: {
         'screen': '100vh',
       },
-      width: {
-        'mobile': '320px',
+      maxWidth: {
+        container: '586px',
       },
       zIndex: {
         'status-bar': '100',


### PR DESCRIPTION
## Summary
- allow the viewport to match device width
- remove old mobile width utility
- center pages with a max width container
- stretch navigation components to full width
- widen fixed subscribe button

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687a0cb8eeb88330abd2e121ea07df88